### PR TITLE
Remove window flicker

### DIFF
--- a/lib/fusionAddInUtils/general_utils.py
+++ b/lib/fusionAddInUtils/general_utils.py
@@ -58,7 +58,7 @@ def clipText(linkText):
     linkText -- string to copy to system clipboard.
     """
     if os.name == "nt":
-        subprocess.run(["clip.exe"], input=linkText.strip().encode("utf-8"), check=True)
+        subprocess.run(["clip.exe"], input=linkText.strip().encode("utf-8"), check=True, shell=True)
     else:
         os.system(f'echo "{linkText.strip()}" | pbcopy')
     app.log(f"link: {linkText} was added to clipboard")


### PR DESCRIPTION
The shell parameter prevents Windows' command prompt window from popping up briefly when clip.exe is executed